### PR TITLE
add Buffer.appendInt(bytes,uint256) and tests

### DIFF
--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -287,4 +287,15 @@ library Buffer {
         }
         return buf;
     }
+
+    /**
+     * @dev Appends a byte to the end of the buffer. Resizes if doing so would
+     * exceed the capacity of the buffer.
+     * @param buf The buffer to append to.
+     * @param data The data to append.
+     * @return The original buffer.
+     */
+    function appendInt(buffer memory buf, uint data, uint len) internal pure returns(buffer memory) {
+        return writeInt(buf, buf.buf.length, data, len);
+    }
 }

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -14,4 +14,13 @@ contract TestBuffer {
         buf.append("world!");
         Assert.equal(string(buf.buf), "Hello, world!", "Unexpected buffer contents.");
     }
+
+    function testBufferAppendUint8() public {
+        Buffer.buffer memory buf;
+        Buffer.init(buf, 256);
+        buf.append("Hello,");
+        buf.appendUint8(0x20);
+        buf.append("world!");
+        Assert.equal(string(buf.buf), "Hello, world!", "Unexpected buffer contents.");
+    }
 }

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -62,4 +62,23 @@ contract TestBuffer {
       Assert.equal(buf.buf.length, 5, "Expected buffer length to be 5");
       Assert.equal(string(buf.buf), "first", "Unexpected buffer contents");
     }
+
+    function testBufferAppendInt() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 256);
+      buf.append("Hello");
+      buf.appendInt(0x2c20, 2);
+      buf.append("world!");
+      Assert.equal(string(buf.buf), "Hello, world!", "Unexpected buffer contents.");
+    }
+
+    function testBufferResizeAppendInt() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 32);
+      buf.append("01234567890123456789012345678901");
+      buf.appendInt(0x2020, 2);
+      Assert.equal(buf.capacity, 96, "Expected buffer capacity to be 96");
+      Assert.equal(buf.buf.length, 34, "Expected buffer length to be 34");
+      Assert.equal(string(buf.buf), "01234567890123456789012345678901  ", "Unexpected buffer contents");
+    }
 }

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -23,4 +23,43 @@ contract TestBuffer {
         buf.append("world!");
         Assert.equal(string(buf.buf), "Hello, world!", "Unexpected buffer contents.");
     }
+
+    function testBufferResizeAppendUint8() public {
+        Buffer.buffer memory buf;
+        Buffer.init(buf, 32);
+        buf.append("01234567890123456789012345678901");
+        buf.appendUint8(0x20);
+        Assert.equal(buf.capacity, 64, "Expected buffer capacity to be 64");
+        Assert.equal(buf.buf.length, 33, "Expected buffer length to be 33");
+        Assert.equal(string(buf.buf), "01234567890123456789012345678901 ", "Unexpected buffer contents");
+    }
+
+    function testBufferResizeAppendBytes() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 32);
+      buf.append("01234567890123456789012345678901");
+      buf.append("23");
+      Assert.equal(buf.capacity, 96, "Expected buffer capacity to be 96");
+      Assert.equal(buf.buf.length, 34, "Expected buffer length to be 33");
+      Assert.equal(string(buf.buf), "0123456789012345678901234567890123", "Unexpected buffer contents");
+    }
+
+    function testBufferResizeAppendManyBytes() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 32);
+      buf.append("01234567890123456789012345678901");
+      buf.append("0123456789012345678901234567890101234567890123456789012345678901");
+      Assert.equal(buf.capacity, 192, "Expected buffer capacity to be 192");
+      Assert.equal(buf.buf.length, 96, "Expected buffer length to be 96");
+      Assert.equal(string(buf.buf), "012345678901234567890123456789010123456789012345678901234567890101234567890123456789012345678901", "Unexpected buffer contents");
+    }
+
+    function testBufferZeroSized() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 0);
+      buf.append("first");
+      Assert.equal(buf.capacity, 32, "Expected buffer capacity to be 32");
+      Assert.equal(buf.buf.length, 5, "Expected buffer length to be 5");
+      Assert.equal(string(buf.buf), "first", "Unexpected buffer contents");
+    }
 }


### PR DESCRIPTION
These are a couple of tests that I pulled over from the [CBOR utils version of Buffer](https://github.com/smartcontractkit/solidity-cborutils/blob/master/contracts/Buffer.sol), in an effort to consolidate the repos. The `append(bytes)` tests are slightly altered, due to a [small difference](https://github.com/ensdomains/buffer/blob/master/contracts/Buffer.sol#L95) in [implementation](https://github.com/smartcontractkit/solidity-cborutils/blob/master/contracts/Buffer.sol#L45) between the two repos. I believe the ENS version's resizing logic is preferable, so altered the tests to match that.

I also added `Buffer.appendInt(bytes,uint256)`, with tests, to match the CBOR implementation.