### PR TITLE
Add spdx license identifier

### DIFF
--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -298,6 +298,7 @@ library Buffer {
      * exceed the capacity of the buffer.
      * @param buf The buffer to append to.
      * @param data The data to append.
+     * @param len The number of bytes to write (right-aligned).
      * @return The original buffer.
      */
     function appendInt(buffer memory buf, uint data, uint len) internal pure returns(buffer memory) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/buffer",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/buffer",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1658,7 +1658,7 @@
           "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
           "dev": true,
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+            "bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -13315,7 +13315,7 @@
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/buffer",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "requires": true,
   "lockfileVersion": 1,
   "devDependencies": {

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 pragma solidity >=0.8.4;
 
 import "./../contracts/Buffer.sol";


### PR DESCRIPTION
- Adds the [appropriate SPDX identifier](https://spdx.org/licenses/BSD-2-Clause.html) to silence compiler warnings
- Fixes https://github.com/ensdomains/buffer/issues/6
- Bumps package dependencies and version