### PR TITLE
fix the overflow for appending uint256

### DIFF
--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -243,16 +243,18 @@ library Buffer {
             resize(buf, newCapacity * 2);
         }
 
-        uint mask = (256 ** len) - 1;
-        assembly {
-            // Memory address of the buffer data
-            let bufptr := mload(buf)
-            // Address = buffer address + sizeof(buffer length) + newCapacity
-            let dest := add(bufptr, newCapacity)
-            mstore(dest, or(and(mload(dest), not(mask)), data))
-            // Update buffer length if we extended it
-            if gt(newCapacity, mload(bufptr)) {
-                mstore(bufptr, newCapacity)
+        unchecked {
+            uint mask = (256 ** len) - 1;
+            assembly {
+                // Memory address of the buffer data
+                let bufptr := mload(buf)
+                // Address = buffer address + sizeof(buffer length) + newCapacity
+                let dest := add(bufptr, newCapacity)
+                mstore(dest, or(and(mload(dest), not(mask)), data))
+                // Update buffer length if we extended it
+                if gt(newCapacity, mload(bufptr)) {
+                    mstore(bufptr, newCapacity)
+                }
             }
         }
         return buf;

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -110,5 +110,11 @@ contract TestBuffer {
         keccak256(abi.encodePacked(string(buf.buf))) == keccak256(abi.encodePacked("01234567890123456789012345678901  ")),
         "Unexpected buffer contents."
       );
+      buf.appendInt(0x2020202020202020202020202020202020202020202020202020202020202020, 32);
+      require(buf.buf.length == 66, "Expected buffer length to be 66");
+      require(
+        keccak256(abi.encodePacked(string(buf.buf))) == keccak256(abi.encodePacked("01234567890123456789012345678901                                  ")),
+        "Unexpected buffer contents."
+      );
     }
 }


### PR DESCRIPTION
If using `appendInt()` to append an uint256 with the size 32, `uint mask = (256 ** len) - 1;` will overflow and revert.
It can be fixed by adding `unchecked` block like `append()`